### PR TITLE
challenge should be an sha256 of the verifier

### DIFF
--- a/teslauth/src/main/java/energy/octopus/octopusenergy/teslauth/util/CodeChallenge.kt
+++ b/teslauth/src/main/java/energy/octopus/octopusenergy/teslauth/util/CodeChallenge.kt
@@ -2,11 +2,12 @@ package energy.octopus.octopusenergy.teslauth.util
 
 import android.util.Base64
 import android.util.Base64.NO_PADDING
+import android.util.Base64.NO_WRAP
 import android.util.Base64.URL_SAFE
 import org.apache.commons.lang3.RandomStringUtils
 
 internal class CodeChallenge {
-    val verifier = RandomStringUtils.randomAlphabetic(86)
-    val challenge = Base64.encodeToString(verifier.toByteArray(), NO_PADDING or URL_SAFE)
+    val verifier: String = RandomStringUtils.randomAlphabetic(86)
+    val challenge: String = Base64.encodeToString(verifier.sha256(), NO_PADDING or NO_WRAP or URL_SAFE)
     val method = "S256"
 }

--- a/teslauth/src/main/java/energy/octopus/octopusenergy/teslauth/util/Cryptography.kt
+++ b/teslauth/src/main/java/energy/octopus/octopusenergy/teslauth/util/Cryptography.kt
@@ -1,0 +1,8 @@
+package energy.octopus.octopusenergy.teslauth.util
+
+import java.security.MessageDigest
+
+internal fun String.sha256(): ByteArray {
+    val digest = MessageDigest.getInstance("SHA-256")
+    return digest.digest(toByteArray(charset("UTF-8")))
+}


### PR DESCRIPTION
The following error started occurring on attempting to retrieve an auth token...

https://github.com/timdorr/tesla-api/discussions/689

Tesla now require the `challenge` to be the `SHA-256` hash of the `code_verifier`.